### PR TITLE
Bugfix: Ensure README has GitHub Codespaces instructions and app.py housekeeping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,38 @@ Use Python to explore a website's internal links. Then apply D3 to visualize tho
 ### Steps
 
 1. Install the above programs.
+
 2. Open a shell window (For Windows open PowerShell, for MacOS open Terminal & for Linux open your distro's terminal emulator).
+
 3. Clone this repository using `git` by running the following command: `git clone git@github.com:devbret/website-internal-links.git`.
+
 4. Navigate to the repo's directory by running: `cd website-internal-links`.
+
 5. Create a virtual environment with this command: `python3 -m venv venv`. Then activate your virutal environment using: `source venv/bin/activate`.
+
 6. Install the needed dependencies for running the script by running: `pip install -r requirements.txt`.
-7. Edit the app.py file on line 154, to include the website you would like to visualize. Also edit the app.py file on line 51 to specify how many pages you would like to crawl.
+
+7. Edit the app.py file `website_to_crawl` variable (on line 17), this is the website you would like to visualize.
+    - Also edit the app.py file `website_crawl_level` variable (on line 20), this specifies how many pages you would like to crawl.
+
 8. Run the script with the command `python3 app.py`.
+
 9. To view the website's connections using the index.html file you will need to run a local web server. To do this run: `python3 -m http.server`.
+
 10. Once the network map has been launched, hover over any given node for more information about the particular web page. By clicking on a node, you will be sent to the related URL address.
+
+11. To exit the virtual environment (venv), type: `deactivate` in the terminal.
 
 ## Please Also Consider
 
 Generating visualizations for this app takes an unexpectedly large amount of processing power. It is thus advisable to initially experiment with mapping less than one hundred pages per launch.
+
+## Troubleshooting
+
+If working with GitHub codespaces, you may have to:
+    - `python -m nltk.downloader punkt_tab`
+    - reattempt steps 7 - 10 
+
+All else fails, contact the maintainer on here or via LinkedIn.
+
+Cheers!

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Use Python to explore a website's internal links. Then apply D3 to visualize tho
 
 4. Navigate to the repo's directory by running: `cd website-internal-links`.
 
-5. Create a virtual environment with this command: `python3 -m venv venv`. Then activate your virutal environment using: `source venv/bin/activate`.
+5. Create a virtual environment with this command: `python3 -m venv venv`. Then activate your virtual environment using: `source venv/bin/activate`.
 
 6. Install the needed dependencies for running the script by running: `pip install -r requirements.txt`.
 
-7. Edit the app.py file `website_to_crawl` variable (on line 17), this is the website you would like to visualize.
-    - Also edit the app.py file `website_crawl_level` variable (on line 20), this specifies how many pages you would like to crawl.
+7. Edit the app.py file `WEBSITE_TO_CRAWL` variable (on line 17), this is the website you would like to visualize.
+    - Also edit the app.py file `MAX_PAGES_TO_CRAWL` variable (on line 20), this specifies how many pages you would like to crawl.
 
 8. Run the script with the command `python3 app.py`.
 

--- a/app.py
+++ b/app.py
@@ -13,6 +13,12 @@ import re
 nltk.download('punkt')
 nltk.download('stopwords')
 
+# The website you would like to visualize.
+website_to_crawl='https://example.com'
+
+# Specify how many pages you would like to crawl.
+website_crawl_level=10
+
 def is_internal(url, base):
     return urlparse(url).netloc == urlparse(base).netloc
 
@@ -48,7 +54,7 @@ def check_form_labels(soup):
             inputs_without_labels.append(field['id'])
     return inputs_without_labels
 
-def crawl_site(start_url, max_links=25):
+def crawl_site(start_url, max_links=website_crawl_level):
     visited = set()
     site_structure = {}
 
@@ -151,5 +157,5 @@ def save_links_as_json(site_structure, filename='links.json'):
     with open(filename, 'w') as file:
         json.dump(site_structure, file, indent=2)
 
-site_structure = crawl_site('https://www.example.com/')
+site_structure = crawl_site(website_to_crawl)
 save_links_as_json(site_structure)

--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ nltk.download('punkt')
 nltk.download('stopwords')
 
 # The website you would like to visualize.
-WEBSITE_TO_CRAWL = 'https://ba-calderonmorales.github.io/my-life-as-a-dev/'
+WEBSITE_TO_CRAWL = 'https://example.com'
 
 # Specify how many pages you would like to crawl.
 MAX_PAGES_TO_CRAWL = 20

--- a/app.py
+++ b/app.py
@@ -14,10 +14,10 @@ nltk.download('punkt')
 nltk.download('stopwords')
 
 # The website you would like to visualize.
-website_to_crawl='https://example.com'
+WEBSITE_TO_CRAWL = 'https://ba-calderonmorales.github.io/my-life-as-a-dev/'
 
 # Specify how many pages you would like to crawl.
-website_crawl_level=10
+MAX_PAGES_TO_CRAWL = 20
 
 def is_internal(url, base):
     return urlparse(url).netloc == urlparse(base).netloc
@@ -54,7 +54,7 @@ def check_form_labels(soup):
             inputs_without_labels.append(field['id'])
     return inputs_without_labels
 
-def crawl_site(start_url, max_links=website_crawl_level):
+def crawl_site(start_url, max_links=MAX_PAGES_TO_CRAWL):
     visited = set()
     site_structure = {}
 
@@ -157,5 +157,5 @@ def save_links_as_json(site_structure, filename='links.json'):
     with open(filename, 'w') as file:
         json.dump(site_structure, file, indent=2)
 
-site_structure = crawl_site(website_to_crawl)
+site_structure = crawl_site(WEBSITE_TO_CRAWL)
 save_links_as_json(site_structure)


### PR DESCRIPTION
When testing out GitHub Codespaces with tool I ran into an issue with some of the dependencies.

This PR intends to cover the following bullet points:

- added some whitespace between each step.
- using variables instead of hard coded values.
- added some comments to app.py to help devs crawl faster.
- ensure code reflects what documentation has.
- added deactivate step to exit venv.
- ensure that we use the example.com site.

Spoke to Bret about this over LinkedIn and we talked about the issues I was seeing.

If anyone else sees these things, please raise another PR and link this one so that we can keep track of issues related to the same dependencies (if they happen to cause issues in the future).

Github Codespaces:

![image](https://github.com/user-attachments/assets/8ad51956-8f0c-4a23-bd5e-020571ca9a31)

Pulling 10 levels deep works after ensuring steps are added to README/followed when using tool in GitHub Codespaces:

![image](https://github.com/user-attachments/assets/c6c094fe-7f72-4d0d-9404-369e760d7803)

Proof that it's running in GitHub Codespaces:

![image](https://github.com/user-attachments/assets/c0c7c72d-cabf-4f64-90d0-811d6c3055e4)

Site when "Open in browser" button clicked:

![image](https://github.com/user-attachments/assets/28bbfe27-3d16-45d5-9da4-ecca2481fde2)

Solid tool @devbret !