### PR TITLE
Bump nltk from 3.9.1 to 3.10.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ Jinja2==3.1.6
 jiter==0.10.0
 joblib==1.4.2
 MarkupSafe==3.0.2
-nltk==3.9.1
+nltk==3.10.3
 pydantic==2.11.7
 pydantic_core==2.33.2
 pyphen==0.16.0


### PR DESCRIPTION
Updates `nltk` to address PYSEC-2026-96, PYSEC-2026-97, PYSEC-2026-98, PYSEC-2026-99, PYSEC-2026-2235, PYSEC-2026-2236, PYSEC-2026-2237, PYSEC-2026-3581, PYSEC-2026-3582, PYSEC-2026-3583, PYSEC-2026-3584, PYSEC-2026-3657, PYSEC-2026-597, PYSEC-2026-2078, PYSEC-2026-2085, GHSA-rf74-v2fm-23pw.

Evidence:
- `requirements.txt` referenced `nltk==3.9.1`
- `osv-scanner` reported the advisory IDs above for `nltk@3.9.1` before the update
- updated version: `nltk==3.10.3`

Validation:
- `osv-scanner` no longer reports any advisory for `nltk@3.10.3` after the update
- OSV API query for nltk 3.10.3 returns no known vulnerabilities

Scope: dependency pin update in `requirements.txt` only.

Note: `osv-scanner` still reports separate advisories for other pinned packages (requests, setuptools, soupsieve, urllib3, werkzeug). This patch only updates `nltk`.